### PR TITLE
Add media queries for small and very small screens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -144,3 +144,33 @@ code {
   text-align: left;
   padding-bottom: 2%;
 }
+
+@media only screen and (max-width: 700px) {
+  .story-number {
+    width: 2.5%;
+    padding: 0 2%;
+  }
+
+  .search-input {
+    width: 45%;
+  }
+
+  .story {
+    margin: 0.5% 0;
+  }
+}
+
+@media only screen and (max-width: 450px) {
+  .story-number {
+    width: 5%;
+    padding: 0 2.5%;
+  }
+
+  .search-input {
+    width: 55%;
+  }
+
+  .story {
+    margin: 0.75% 0;
+  }
+}


### PR DESCRIPTION
I added media queries at 700px and at 450px to do the following; 
* Increase margins between stories
* Increase padding and width of the story numbers so that they don't overlap story text
* Increase the width of the search input

This will render the app more visually appealing on iPhone-sized screens, particularly iPhone SE or similarly sized small or very small screens. I added the media query at 700px so that the changes would flow more smoothly on intermediate screen sizes as the screen size scaled up/down.